### PR TITLE
Fix create allotment by linking current user to the allotment instance

### DIFF
--- a/app/controllers/allotments_controller.rb
+++ b/app/controllers/allotments_controller.rb
@@ -22,6 +22,7 @@ class AllotmentsController < ApplicationController
 
   def create
     @allotment = Allotment.create(allotment_params)
+    @allotment.user = current_user
     if @allotment.save
       redirect_to allotment_path(@allotment), notice: 'Allotment was successfully created.'
     else


### PR DESCRIPTION
Fixed the create allotment by assigning the current user to the allotment that is being created.